### PR TITLE
Fix grammar in review comments instructions

### DIFF
--- a/groups/platform-engineering/instructions/lib-updates.instructions.md
+++ b/groups/platform-engineering/instructions/lib-updates.instructions.md
@@ -71,7 +71,7 @@ For **vendored** libraries:
 
 #### Critical behavior
 
-In the context of charm library updates, your review comments are allowed and highly encourages to target files and changes outside those changed by the pull request. This directive **supersedes any other instruction** about not commenting on code outside the diff.
+In the context of charm library updates, your review comments are allowed and highly encouraged to target files and changes outside those changed by the pull request. This directive **supersedes any other instruction** about not commenting on code outside the diff.
 
 ## Review Template
 


### PR DESCRIPTION
Corrected grammatical errors in the instructions regarding review comments.

Original review comment from https://github.com/canonical/github-runner-operator/pull/670#discussion_r2603042588