### PR TITLE
Add new PFE collection bases 

### DIFF
--- a/collections.yaml
+++ b/collections.yaml
@@ -9,8 +9,6 @@ core:
   items:
     - src: assets/instructions/common/instructions.instructions.md
       dest: .github/instructions/instructions.instructions.md
-    - src: assets/instructions/common/core-directive.instructions.md
-      dest: .github/instructions/core-directive.instructions.md
     - src: assets/prompts/repo-bootstrap.prompt.md
       dest: .github/prompts/repo-bootstrap.prompt.md
 
@@ -24,7 +22,7 @@ common-python:
 # 2. Framework Specifics 
 # ==========================================
 charm-python:
-  description: "Full Python Charm Development Kit"
+  description: "Charm Development with Python"
   includes: 
     - core
     - common-python

--- a/groups/platform-engineering/collections.yaml
+++ b/groups/platform-engineering/collections.yaml
@@ -2,25 +2,23 @@ pfe-core:
   description: "Platform Engineering Core Collection"
   includes:
     - core
-  items: []
-
-pfe-docs:
-  description: "Platform Engineering Documentation Collection"
-  includes:
-    - pfe-core
   items:
     - src: /assets/instructions/documentation/documentation.instructions.md
       dest: .github/instructions/documentation.instructions.md
+
+pfe-docs:
+  description: "Platform Engineering RTD Documentation Collection"
+  includes:
+    - pfe-core
+  items:
     - src: /assets/instructions/documentation/documentation-rtd.instructions.md
       dest: .github/instructions/documentation-rtd.instructions.md
 
 pfe-docs-not-rtd:
-  description: "Platform Engineering none-RTD based Documentation Collection"
+  description: "Platform Engineering none-RTD Documentation Collection"
   includes:
     - pfe-core
   items:
-    - src: /assets/instructions/documentation/documentation.instructions.md
-      dest: .github/instructions/documentation.instructions.md
     - src: /assets/instructions/documentation/documentation-not-rtd.instructions.md
       dest: .github/instructions/documentation-not-rtd.instructions.md
 

--- a/groups/platform-engineering/collections.yaml
+++ b/groups/platform-engineering/collections.yaml
@@ -1,8 +1,37 @@
+pfe-core:
+  description: "Platform Engineering Core Collection"
+  includes:
+    - core
+  items: []
+
+pfe-docs:
+  description: "Platform Engineering Documentation Collection"
+  includes:
+    - pfe-core
+  items:
+    - src: /assets/instructions/documentation/documentation.instructions.md
+      dest: .github/instructions/documentation.instructions.md
+    - src: /assets/instructions/documentation/documentation-rtd.instructions.md
+      dest: .github/instructions/documentation-rtd.instructions.md
+
+pfe-docs-not-rtd:
+  description: "Platform Engineering none-RTD based Documentation Collection"
+  includes:
+    - pfe-core
+  items:
+    - src: /assets/instructions/documentation/documentation.instructions.md
+      dest: .github/instructions/documentation.instructions.md
+    - src: /assets/instructions/documentation/documentation-not-rtd.instructions.md
+      dest: .github/instructions/documentation-not-rtd.instructions.md
+
 pfe-charms:
   description: "Platform Engineering Charm Development Collection"
   includes:
+    - pfe-core
     - charm-python
   items:
     # Path is relative to groups/platform-engineering/
     - src: instructions/lib-updates.instructions.md
       dest: .github/instructions/charms-lib-updates.instructions.md
+    - src: assets/instructions/common/core-directive.instructions.md
+      dest: .github/instructions/core-directive.instructions.md

--- a/groups/platform-engineering/collections.yaml
+++ b/groups/platform-engineering/collections.yaml
@@ -15,7 +15,7 @@ pfe-docs:
       dest: .github/instructions/documentation-rtd.instructions.md
 
 pfe-docs-not-rtd:
-  description: "Platform Engineering none-RTD Documentation Collection"
+  description: "Platform Engineering non-RTD Documentation Collection"
   includes:
     - pfe-core
   items:

--- a/groups/platform-engineering/collections.yaml
+++ b/groups/platform-engineering/collections.yaml
@@ -31,5 +31,5 @@ pfe-charms:
     # Path is relative to groups/platform-engineering/
     - src: instructions/lib-updates.instructions.md
       dest: .github/instructions/charms-lib-updates.instructions.md
-    - src: assets/instructions/common/core-directive.instructions.md
+    - src: /assets/instructions/common/core-directive.instructions.md
       dest: .github/instructions/core-directive.instructions.md


### PR DESCRIPTION
## Summary

Added a few new PFE specific collections so serve as base for future collections as well as initial "subscription" points for some of our repositories.

- `pfe-core`: Serves as a layer between the global `core` collection, allowing us to add additional "team specific" assets we believe should be present in all our repositories. 
    - The generic documentation instructions was added within the `pfe-core` collection. 
- `pfe-docs`: Define the assets that should be included for any repository that contains RTD based documentation.
- `pfe-docs-not-rtd`: Define the assets that should be included for any repository that contains  none-RTD based documentation.
- `pfe-charms`: Base collection that should be included in all our charm repositories.

Note: Removed the `core-directives` instruction set from the global `core` collection to make sure core only includes generic assets. 