### PR TITLE
Update documentation instructions

### DIFF
--- a/assets/instructions/documentation/documentation-not-rtd.instructions.md
+++ b/assets/instructions/documentation/documentation-not-rtd.instructions.md
@@ -15,7 +15,7 @@ The CI expects documentation to pass `vale` and `lychee`; address reported issue
 
 ### Linting & checks (how to run)
 
-Run the docs linters via the top-level Makefile targets: `make docs-check` (this runs `vale` and `lychee`).
+Run the docs linters using the top-level Makefile targets: `make docs-check` (this runs `vale` and `lychee`).
 
 ## Small-edit rules for AI agents
 

--- a/assets/instructions/documentation/documentation-release-notes.instructions.md
+++ b/assets/instructions/documentation/documentation-release-notes.instructions.md
@@ -1,0 +1,72 @@
+---
+description: 'Core guidelines for automated release notes process.'
+applyTo: 'docs/**/*.md'
+---
+
+# Release notes instructions for GitHub Copilot
+
+## Purpose
+
+This file provides general guidance for the automated release notes process.
+
+The release notes process is a semi-automated system that ensures every significant change is tracked and eventually compiled into a standardized release document.
+
+## Overview of the release notes workflow
+
+1. The workflow is triggered when a new release artifact is added to the repository’s main branch.
+2. Both the repository and the `release-notes-automation` are checked out. Python and other required
+   dependencies are installed and configured.
+3. The Python script runs over the prepared materials and artifacts, generating a Markdown file for the release notes.
+4. A pull request is opened into the repository that adds the Markdown file into the ``docs/release-notes`` directory.
+
+For a contributor, the workflow is divided into three main stages: change tracking, release definition, and automated generation.
+
+### Change Tracking (The "Artifact" Phase)
+
+When a developer contributes a change via a pull request, they are expected to include a **change artifact**.
+
+* **Artifact Template**: A YAML file created from `docs/release-notes/template/_change-artifact-template.yaml`. It captures the change title, author, type (e.g., bugfix, breaking), description, and relevant PR or issue links.
+* **PR Compliance**: The `Check for release notes artifact` workflow runs on every pull request. It uses the `canonical/release-notes-automation` reusable workflow to verify that the required artifact has been added to the `docs/release-notes/artifacts` directory.
+
+### Release Definition
+
+When a set of changes is ready to be released, a maintainer defines the release parameters.
+
+* **Release Artifact**: A YAML file is created in `docs/release-notes/releases/` based on the `_release-artifact-template.yaml`.
+* **Content**: This file lists the specific change artifacts to include and specifies the workload version and the range of charm revisions covered by the release.
+
+### Automated Generation
+
+The final Markdown documentation is generated automatically when the release definition is pushed to the main branch.
+
+* **Automation Trigger**: The `Create release notes` workflow triggers on pushes to `main` that modify files in `docs/release-notes/releases/*`.
+* **Assembly**: The workflow gathers data from several sources:
+* **Common Metadata**: Basic info like the charm name and release track from `docs/release-notes/common.yaml`.
+* **Templates**: A Jinja2 template (`release-template.md.j2`) provides the structure for the final Markdown file.
+* **Output**: The resulting Markdown file is generated in the `docs/release-notes/` directory.
+
+## Change artifacts
+
+The `changes` key contains the following values:
+
+* `title`: This value is typically be used to define headers for the change. For bug fixes, this value is be used as the description of the entry. 
+* `author`: GitHub profile name of the person creating the change.
+* `type`: Scope of the change. Accepted values (that the tool will recognize) are major, minor, bugfix, deprecated, breaking.
+* `description`: This value is used to define the context and provide more information about the change. It is used for all changes except for type: bugfix.
+* `urls`: Relevant URLs for the change. `urls.pr` is an array containing one or more links to the associated PR(s), `urls.related_doc` is an optional link to relevant documentation, and `urls.related_issue` is an optional link to a relevant GitHub issue.
+* `visibility`: This value determines whether the change is public or internal. Accepted values (that the tool will recognize) are `public` (default), `internal`, and `hidden`.
+* `highlight`: This boolean determines whether the change is mentioned in the Introduction of the release notes.
+
+### Style considerations
+
+* `title`: For features, keep the titles short and concise. Use past tense in the title for all artifacts. Do not use punctuation.
+* `author`: Only use the GitHub profile name (no emails, no `@`).
+* `type`: To determine whether the type is `major` or `minor`, ask yourself whether the change will be immediately seen or felt by users (meaning it’s more likely to be a `major` change), or if the change is less likely to affect the user experience in a meaningful way (meaning it’s more likely to be a `minor` change).
+* `description`: Use past tense to provide context and information. The more information you provide in the description, the less context you’ll need to provide when the release notes are being prepared for publication. Describe the change in terms of how it will impact users and their experience with the product.
+* `urls.pr`: For a change artifact containing multiple URLs to pull requests, the `urls.pr` key should be formatted as an array containing all the links.
+* `urls.related_doc`: Only use this key for publicly visible documentation. If documentation was updated in the pull request, use this key to link to that page or file.
+
+Set `highlight` to true for the following reasons:
+* If the `type` is deprecated, there’s a good chance that the change is worth highlighting.
+* If the `type` is `major` or `bugfix` and has a significant impact on the user experience, then the change is probably worth highlighting.
+

--- a/assets/instructions/documentation/documentation-release-notes.instructions.md
+++ b/assets/instructions/documentation/documentation-release-notes.instructions.md
@@ -1,6 +1,6 @@
 ---
 description: 'Core guidelines for automated release notes process.'
-applyTo: 'docs/**/*.md'
+applyTo: 'docs/release-notes/artifacts/**'
 ---
 
 # Release notes instructions for GitHub Copilot
@@ -47,6 +47,8 @@ The final Markdown documentation is generated automatically when the release def
 
 ## Change artifacts
 
+The change artifact filename should be formatted like `CYCLE_SLUG.yaml`, where `CYCLE` represents the cycle in which the change occurred (e.g. `2604`), and `SLUG` represents a unique identifier that briefly summarizes the change. For example, a change artifact summarizing a new feature in the `2604` cycle should be named `2604_new_feature.yaml`.
+
 The `changes` key contains the following values:
 
 * `title`: This value is typically be used to define headers for the change. For bug fixes, this value is be used as the description of the entry. 
@@ -56,6 +58,8 @@ The `changes` key contains the following values:
 * `urls`: Relevant URLs for the change. `urls.pr` is an array containing one or more links to the associated PR(s), `urls.related_doc` is an optional link to relevant documentation, and `urls.related_issue` is an optional link to a relevant GitHub issue.
 * `visibility`: This value determines whether the change is public or internal. Accepted values (that the tool will recognize) are `public` (default), `internal`, and `hidden`.
 * `highlight`: This boolean determines whether the change is mentioned in the Introduction of the release notes.
+
+Feature development split over multiple PRs should be described in a single change artifact, with links to all associated PRs added into the artifact under the key `urls.pr`.
 
 ### Style considerations
 

--- a/assets/instructions/documentation/documentation.instructions.md
+++ b/assets/instructions/documentation/documentation.instructions.md
@@ -107,7 +107,7 @@ problem or achieve the goal.
 
 ## Changelog guidance 
 
-If you modify a procedure (commands, required versions, prerequisites), add a short note in `docs/changelog.md` summarizing the user-facing change.
+If you modify a procedure (commands, required versions, prerequisites) and a `docs/changelog.md` exists, add a short note in `docs/changelog.md` summarizing the user-facing change.
 
 If you add a new file into `docs`, add a short note in `docs/changelog.md` summarizing the user-facing change.
 

--- a/assets/instructions/documentation/documentation.instructions.md
+++ b/assets/instructions/documentation/documentation.instructions.md
@@ -13,12 +13,12 @@ This file provides general guidance for reviewing documentation.
 
 This section outlines the absolute order of operations. These rules have the highest priority and must not be violated.
 
-1. **Provide suggestions, not solutions**: Whenever possible, do not generate the documentation on behalf of the user. Focus on asking questions, providing suggestions, and reviewing pre-existing files.
+1. **Provide suggestions, not solutions**: Whenever possible, do not generate the documentation on behalf of the user. Focus on asking questions, providing suggestions, and reviewing pre-existing files. If you want to make changes, ask for validation before proceeding with any changes.
 2. **Adherence to Philosophy**: In the absence of a direct user directive or the need for factual verification, all other rules below regarding interaction and modification must be followed.
 
 ## General Interaction & Philosophy
 
-- **Text on Request Only**: Your default response should be a clear, natural language explanation. Do NOT provide new files or content unless directly requested.
+- **Text on Request Only**: Your default response should be a clear, natural language explanation. Do NOT provide new files or content unless directly requested, and ask for validation before making any changes to the code base.
 - **Direct and Concise**: Answers must be precise, to the point, and free from unnecessary filler or verbose explanations. Get straight to the solution without "beating around the bush".
 - **Explain the "Why"**: Don't just provide an answer; briefly explain the reasoning behind it. Why is this suggestion clearer, more concise, or easier to understand?
 
@@ -94,17 +94,23 @@ problem or achieve the goal.
 ## Style guide pointers
 
 - **Spelling**: Use US English for spelling suggestions.
-- **Headings**: Use sentence case for headings. Avoid punctuation in headings. Do not skip levels in heading hierarchy.
+- **Headings**: Use sentence case for headings. Avoid punctuation in headings. Do not skip levels in heading hierarchy. Do not use consecutive headings without intervening text, and suggest removing headings that don't enhance the understanding. Don't overuse `code` styling in headings.
 - **Code examples**: Do not use prompt marks (for example, `$` or `#`) in code examples. Do not use comments in code examples; instead, put any comments directly into the text. Whenever possible, split up multiple commands into separate code blocks and provide explanations in between the code blocks. Use Git-flavoured Markdown with fenced code blocks (```) and command examples as shell blocks.
+- **Lists**: Only use numbered lists when there is an inherent order to the items.
+- **Latin words and phrases**: We can't assume the reader is familiar with Latin words and phrases. Words such as "etc.", "i.e.", "e.g.", "per", "versus", and "via" should be avoided. 
 
 ## Small-edit rules for AI agents
 
 - Avoid describing tasks as "easy" or "simple".
 - Preserve existing link targets and code samples formatting. If you change any heading filename or path, update all relative links in `docs/` accordingly.
+- Demonstrative pronouns ("this", "these", "those", and "that") should be accompanied by the target noun when there's a risk of ambiguity in the paragraph. An isolated demonstrative pronoun can be used if there's no chance of ambiguity. In cases where a paragraph describes multiple ideas, avoid isolated demonstrative pronouns and be as specific as possible.
 
 ## Changelog guidance 
 
 If you modify a procedure (commands, required versions, prerequisites), add a short note in `docs/changelog.md` summarizing the user-facing change.
 
 If you add a new file into `docs`, add a short note in `docs/changelog.md` summarizing the user-facing change.
+
+If there are no user-relevant changes, then the changelog does not need to be updated.
+
 


### PR DESCRIPTION
Updates to the documentation-related instructions:
* Additional style considerations
* Attempt to curb behavior where Copilot makes changes directly to documents by requesting that Copilot asks for validation beforehand.
* Add a new instructions document, `assets/instructions/documentation/documentation-release-notes.instructions.md`, which provides context and an overview of the automated release notes process, specifically the change artifacts.