### PR TITLE
Add support for Agent Skills along with Documentation Skill

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,6 +7,7 @@ This repository is the "Toolkit" for centralized context management for GitHub C
 - **Type**: Utility/Toolkit.
 - **Languages**: Bash (logic), YAML (configuration), Markdown (content).
 - **Core Function**: Individual repositories define a `.copilot-collections.yaml` file listing "Collections" they need. This toolkit's scripts (`install_collections.sh`) parse that config and sync the corresponding Markdown files from `assets/` or `groups/<team>/` into the consumer's `.github/` directory.
+- **Supported Artifacts**: Custom Instructions, Prompts, and Agent Skills.
 - **Key Tools**: `yq` (YAML processing), `shellcheck` (Script linting).
 
 ## Project Layout
@@ -14,6 +15,10 @@ This repository is the "Toolkit" for centralized context management for GitHub C
 ### Directories
 - **`collections.yaml`**: The ROOT configuration file defining "Core" collections.
 - **`assets/`**: Contains the source Markdown files for core collections.
+    - `instructions/`: Custom instruction files organized by category.
+    - `prompts/`: Prompt template files.
+    - `agents/`: Agent definition files.
+    - `skills/`: Agent skill directories (each containing SKILL.md with YAML frontmatter).
 - **`groups/`**: Contains team-specific collections.
     - Each subfolder (e.g., `groups/charm-tech/`) acts as a mini-repo with its own `collections.yaml` and asset folder.
 - **`scripts/`**: Contains the logic binaries.
@@ -91,6 +96,25 @@ yq eval . collections.yaml > /dev/null
 2.  Add `groups/<team-name>/collections.yaml` following the schema.
 3.  Add assets in that folder.
 4.  Run validation.
+
+### Adding an Agent Skill
+1.  **Create Directory**: Create `assets/skills/<skill-name>/` (or `groups/<team>/skills/<skill-name>/` for team skills).
+2.  **Create SKILL.md**: Add the skill definition with required YAML frontmatter:
+    ```markdown
+    ---
+    name: skill-name
+    description: Brief description of what the skill does
+    ---
+    # Skill Instructions
+    Detailed content here...
+    ```
+3.  **Update Manifest**: Edit `collections.yaml` and add to a collection's `items`:
+    ```yaml
+    - src: assets/skills/<skill-name>
+      dest: .github/skills/<skill-name>/
+    ```
+    **Critical**: Since skills are directories, `dest` MUST end with `/` or validation will fail.
+4.  **Validate**: Run `./scripts/validate_collections.sh .`.
 
 ## CI/CD 
 The `Test Toolkit` workflow (`.github/workflows/test-toolkit.yaml`) runs automatically on PRs. It executes the linting, validation, and test steps listed above. If your local `./scripts/validate_collections.sh .` passes, CI should pass.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,96 @@
+# Copilot Instructions for `canonical/copilot-collections`
+
+This repository is the "Toolkit" for centralized context management for GitHub Copilot across the Canonical ecosystem. It distributes standardized Copilot Custom Instructions and Prompts to other repositories via a subscription model.
+
+## High Level Details
+
+- **Type**: Utility/Toolkit.
+- **Languages**: Bash (logic), YAML (configuration), Markdown (content).
+- **Core Function**: Individual repositories define a `.copilot-collections.yaml` file listing "Collections" they need. This toolkit's scripts (`install_collections.sh`) parse that config and sync the corresponding Markdown files from `assets/` or `groups/<team>/` into the consumer's `.github/` directory.
+- **Key Tools**: `yq` (YAML processing), `shellcheck` (Script linting).
+
+## Project Layout
+
+### Directories
+- **`collections.yaml`**: The ROOT configuration file defining "Core" collections.
+- **`assets/`**: Contains the source Markdown files for core collections.
+- **`groups/`**: Contains team-specific collections.
+    - Each subfolder (e.g., `groups/charm-tech/`) acts as a mini-repo with its own `collections.yaml` and asset folder.
+- **`scripts/`**: Contains the logic binaries.
+    - `install_collections.sh`: The main engine that reads config and copies files.
+    - `validate_collections.sh`: Validates referential integrity of `collections.yaml` files.
+    - `local_sync.sh`: A wrapper for local usage by consumers.
+- **`tests/`**: Contains test scripts for the bash logic.
+- **`.github/workflows/`**:
+    - `test-toolkit.yaml`: The CI pipeline for this repo.
+    - `auto_update_collections.yaml`: A **reusable workflow** imported by consumer repos to auto-update their instructions.
+
+### Architecture
+The system uses a "Pull" model.
+1.  **Manifest**: `collections.yaml` maps a `collection_name` to a list of file operations (`src` -> `dest`).
+2.  **Resolution**: The `install_collections.sh` script takes a consumer config, resolves the requested collections against the manifest, and copies `src` files to `dest`.
+
+## Build and Validation Instructions
+
+**Prerequisites**:
+- Ensure `yq` (v4+) is installed.
+- Ensure `shellcheck` is installed.
+
+### 1. Validate Structure & Integrity
+Before submitting changes (especially when editing `collections.yaml`), run the validator. It checks for:
+- Duplicate collection names.
+- References to missing files in `assets/`.
+- Valid YAML syntax.
+
+```bash
+# Validates the root and all group configurations
+./scripts/validate_collections.sh .
+```
+
+### 2. Run Tests
+The repository includes a test suite for the bash scripts.
+
+```bash
+# Test the validation logic itself
+./tests/test_validate.sh
+
+# Test the installation/sync logic (Integration Test)
+./tests/test_install.sh
+```
+
+### 3. Linting
+Scripts should remain POSIX compliant or Bash-compatible as verified by shellcheck.
+
+```bash
+# Lint all scripts
+shellcheck scripts/*.sh
+```
+
+### 4. Manifest Syntax Check
+If you edited a YAML file, verify it is valid:
+
+```bash
+yq eval . collections.yaml > /dev/null
+```
+
+## Common Tasks
+
+### Adding a New Instruction
+1.  **Create Content**: Add the `.md` file in `assets/instructions/<category>/` (for valid categories see existing folders).
+2.  **Update Manifest**: Edit `collections.yaml`.
+    -   Find the appropriate collection key (e.g., `common-python`).
+    -   Add a new item to the `items` list:
+        ```yaml
+        - src: assets/instructions/<category>/file.md
+          dest: .github/instructions/file.md
+        ```
+3.  **Validate**: Run `./scripts/validate_collections.sh .`.
+
+### Adding a Team Collection
+1.  Create `groups/<team-name>/`.
+2.  Add `groups/<team-name>/collections.yaml` following the schema.
+3.  Add assets in that folder.
+4.  Run validation.
+
+## CI/CD 
+The `Test Toolkit` workflow (`.github/workflows/test-toolkit.yaml`) runs automatically on PRs. It executes the linting, validation, and test steps listed above. If your local `./scripts/validate_collections.sh .` passes, CI should pass.

--- a/README.md
+++ b/README.md
@@ -7,17 +7,18 @@
 
 **Centralized context management for GitHub Copilot across the Canonical ecosystem.**
 
-This repository acts as a "Toolkit" to distribute standardized Copilot Custom Instructions, Prompts, and Agent definitions. It allows individual repositories to "subscribe" to specific sets of instructions (e.g., Python standards, Juju/Ops Framework patterns) and keep them synchronized automatically.
+This repository acts as a "Toolkit" to distribute standardized Copilot Custom Instructions, Prompts, Agents and Skills. It allows individual repositories to "subscribe" to specific sets of assets (e.g., Python standards, Juju/Ops Framework patterns) and keep them synchronized automatically.
 
 ## **What are Collections?**
 
-A **Collection** is a logical group of markdown files (instructions, prompts) defined in `collections.yaml.`
+A **Collection** is a logical group of markdown files (instructions, prompts, agents, and skills) defined in `collections.yaml.`
 
 Instead of copying specific instructions into 50 different repositories manually, the consuming repository defines a configuration file listing the collections it needs.
 
 **Available Collections (Examples):**
 
 * common-python: Standard Python coding style.  
+* common-documentation: Documentation standards with review skill.
 * charm-python: Includes common-python + Juju Ops Framework specifics.  
 * pfe-charms: Platform Engineering specific collection.
 
@@ -48,7 +49,7 @@ You can sync the instructions immediately to your local machine to verify them.
 curl -sL https://raw.githubusercontent.com/canonical/copilot-collections/main/scripts/local_sync.sh | bash
 ```
 
-**Note:** This will generate files in .github/instructions/ and .github/prompts/. Do not edit these files manually; they will be overwritten.
+**Note:** This will generate files in .github/instructions/, .github/prompts/, and .github/skills/. Do not edit these files manually; they will be overwritten.
 
 ### **3. Configure Auto-Updates (CI)**
 
@@ -83,6 +84,10 @@ We highly encourage you to explore it for further inspiration, including advance
 ### **Directory Structure**
 
 * assets/: Raw markdown files (Core assets).
+  * instructions/: Custom instruction files.
+  * prompts/: Prompt files.
+  * agents/: Agent files.
+  * skills/: Agent skill directories (each containing SKILL.md).
 * collections.yaml: Core definitions.
 * groups/: Team specific collections.
   * <team-name>/: Folder for team assets.
@@ -101,6 +106,26 @@ We highly encourage you to explore it for further inspiration, including advance
    * Merge changes to main.
    * Create a new GitHub Release (e.g., v1.1.0).
    * *Consumer repos will pick this up automatically on their next scheduled run.*
+
+### **How to add a new Agent Skill**
+
+1. **Create the directory:** Create `assets/skills/<skill-name>/` (for core) or `groups/<team>/skills/<skill-name>/` (for teams).
+2. **Add SKILL.md:** Create the skill definition file with required YAML frontmatter:
+   ```markdown
+   ---
+   name: skill-name
+   description: What the skill does
+   ---
+   # Skill content here
+   ```
+3. **Update Manifest:** Edit `collections.yaml` and add to a collection's items:
+   ```yaml
+   - src: assets/skills/<skill-name>
+     dest: .github/skills/<skill-name>/
+   ```
+   **Important:** Skills are directories, so `dest` must end with `/`.
+4. **Validate:** Run `./scripts/validate_collections.sh .`
+5. **Release:** Follow the same release process as instructions.
 
 ### **Group Collections**
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2025 Canonical Ltd.
+  ~ Copyright 2026 Canonical Ltd.
   ~ See LICENSE file for licensing details.
 -->
 

--- a/assets/skills/documentation-reviewer/SKILL.md
+++ b/assets/skills/documentation-reviewer/SKILL.md
@@ -36,6 +36,7 @@ Perform the following checks based on the identified category:
     *   [ ] Check that it is prescriptive (steps) rather than descriptive (theory).
 *   **For All Files**:
     *   [ ] Check that content is not mixed (e.g., explanation buried in a valid how-to).
+    *   [ ] Check that content is referenced in the appropriate table of contents (e.g., in the `Contents` section of `docs/index.md` or in the relevant `toctree` directive).
 
 ### 3. Style & Syntax Scan
 Scan the text for these specific violations:

--- a/assets/skills/documentation-reviewer/SKILL.md
+++ b/assets/skills/documentation-reviewer/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: documentation-reviewer
+description: Interactive workflow for reviewing documentation structure, style, and clarity.
+---
+
+# Documentation Reviewer Skill
+
+This skill guides the agent through an interactive review process for documentation files. It focuses on **workflows and validation actions** rather than defining the standards themselves (which are provided in the repo's custom instructions).
+
+## What This Skill Does
+
+This skill instructs the agent to act as a **Documentation Reviewer**. It audits content against the Diataxis framework and Canonical's style guide by performing specific checks.
+
+## Review Workflow
+
+When asked to review documentation, follow this step-by-step process:
+
+### 1. Categorization Check
+*   **Action**: Identify the intended valid Diataxis type of the document (Tutorial, How-to, Reference, or Explanation).
+*   **Validation**:
+    *   Does the file location match the type (e.g., `docs/tutorial/`)?
+    *   Does the content match the definition? (e.g., "How-to" should be task-oriented, not theoretical).
+    *   If the type is ambiguous, ask the user to clarify.
+
+### 2. Structural Audit
+Perform the following checks based on the identified category:
+
+*   **For Tutorials**:
+    *   [ ] Check for a learning-oriented title (not "Getting Started").
+    *   [ ] Verify "What you'll do" and "What you'll need" sections exist.
+    *   [ ] Ensure a "Tear down" or cleanup section is present at the end.
+    *   [ ] Confirm the flow is a complete, linear journey.
+*   **For How-to Guides**:
+    *   [ ] Verify the title follows `# How to <task>` format.
+    *   [ ] Ensure it addresses a specific real-world problem.
+    *   [ ] Check that it is prescriptive (steps) rather than descriptive (theory).
+*   **For All Files**:
+    *   [ ] Check that content is not mixed (e.g., explanation buried in a valid how-to).
+
+### 3. Style & Syntax Scan
+Scan the text for these specific violations:
+*   **Language**: specific check for British English (should be US English).
+*   **Headings**: specific check for Title Case (should be Sentence case) and skipped hierarchy levels.
+*   **Code Blocks**: 
+    *   Look for prompt markers (`$`, `#`, `%`) in shell blocks (should be removed).
+    *   Look for inline comments in code (should be moved to text).
+    *   Verify language tags are present (e.g., `bash`, `yaml`).
+
+### 4. Provide Feedback
+*   **Do not rewrite** the file unless explicitly asked.
+*   **Report Findings**: Group your feedback by "Structure", "Style", and "Clarity".
+*   **Explain Why**: For every suggestion, reference the underlying logic (e.g., "Remove prompt markers to allow for easier copy-pasting").
+
+## Example Prompts
+
+*   "Review this PR for documentation standards."
+*   "Does this new tutorial follow the correct structure?"
+*   "Audit `docs/how-to/backup.md` for style violations."

--- a/collections.yaml
+++ b/collections.yaml
@@ -4,6 +4,9 @@
 # ==========================================
 # 1. Base Definitions
 # ==========================================
+# NOTE: Skills are directories containing SKILL.md and must use directory-to-directory mapping.
+#       Destination should be .github/skills/<skill-name>/ to follow conventions.
+
 core:
   description: "Core assets comment to all"
   items:
@@ -17,6 +20,14 @@ common-python:
   items:
     - src: assets/instructions/python/code-commenting.instructions.md
       dest: .github/instructions/python-code-commenting.instructions.md
+
+common-documentation:
+  description: "Documentation standards and review skill"
+  items:
+    - src: assets/instructions/documentation/documentation.instructions.md
+      dest: .github/instructions/documentation.instructions.md
+    - src: assets/skills/documentation-reviewer
+      dest: .github/skills/documentation-reviewer/
 
 # ==========================================
 # 2. Framework Specifics 

--- a/collections.yaml
+++ b/collections.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # ==========================================

--- a/groups/platform-engineering/collections.yaml
+++ b/groups/platform-engineering/collections.yaml
@@ -13,6 +13,8 @@ pfe-docs:
   items:
     - src: /assets/instructions/documentation/documentation-rtd.instructions.md
       dest: .github/instructions/documentation-rtd.instructions.md
+    - src: /assets/skills/documentation-reviewer
+      dest: .github/skills/documentation-reviewer/
 
 pfe-docs-not-rtd:
   description: "Platform Engineering non-RTD Documentation Collection"

--- a/scripts/install_collections.sh
+++ b/scripts/install_collections.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 6 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 set -e

--- a/scripts/install_collections.sh
+++ b/scripts/install_collections.sh
@@ -55,6 +55,13 @@ while read -r manifest_path; do
     fi
 done < <(find "$TOOLKIT_DIR" -name "collections.yaml")
 
+if [ ! -s "$MERGED_MANIFEST" ]; then
+    echo "❌ Error: No collection manifests found in '$TOOLKIT_DIR'."
+    echo "   Ensure the second argument points to the toolkit root (containing collections.yaml)."
+    rm "$MERGED_MANIFEST"
+    exit 1
+fi
+
 # 3. Parse Collections from Config
 COLLECTIONS_LIST=$(yq '.copilot.collections[]' "$CONFIG_FILE" | tr '\n' ' ')
 

--- a/scripts/install_collections.sh
+++ b/scripts/install_collections.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2025 Canonical Ltd.
+# Copyright 6 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 set -e

--- a/scripts/local_sync.sh
+++ b/scripts/local_sync.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 set -e

--- a/scripts/validate_collections.sh
+++ b/scripts/validate_collections.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 # scripts/validate_collections.sh

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 set -e

--- a/tests/test_validate.sh
+++ b/tests/test_validate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 set -e


### PR DESCRIPTION
## Description

This PR onboards the repository to Copilot with dedicated instructions and introduces support for Copilot Agent Skills as a new artifact type.

##  Changes:
*   **Repo Onboarding**: Added `.github/copilot-instructions.md` to provide coding agents with high-level context, project layout, and validated build/test commands for this repository.
*   **Toolkit Support**: Updated docs to support "Agent Skills" (directory-based artifacts).
*   **New Skill**: Created `documentation-reviewer` (`assets/skills/documentation-reviewer/`), an interactive skill that guides agents through categorization, structural audits, and style checks.
*   **Collection Updates**:
    *   Defined `common-documentation` in the root `collections.yaml`.
    *   Added the reviewer skill to Platform Engineering's `pfe-docs` collection