### PR TITLE
Add documentation note for yq usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Instead of copying specific instructions into 50 different repositories manually
 
 To add Copilot collections to your repository, follow these three steps.
 
+**Note:** These steps assume that if the `yq` tool is already installed, it was installed via snap not via apt. The install scripts rely on behavior from the snap version of `yq`. The apt offering of `yq` doesn't have the behavior the scripts expect, and will fail. If `yq` is not installed, the script will automatically install it via snap.
+
 ### **1. Create the Configuration**
 
 Create a file named `.copilot-collections.yaml` in the root of your repository.


### PR DESCRIPTION
This PR adds a note in the documentation that explains the scripts depend on the snap version of `yq`. 

In my setup, I had `yq` installed from apt, which was causing the scripts to fail with invalid tag references to git ( `"v0.5.0"` instead of `v0.5.0`), and resolving
```
yq -i e "
     .[] .items[] .src |= \"$rel_dir\" + . |
     .[] .items[] .src |= sub(\"^$rel_dir/\", \"\")
     " "${manifest_path}.tmp"
``` 
as a file rather than input. Because the scripts check if the `yq` binary is present in the system path, they run regardless of what yq package is on the system.

It would be a good idea to include this note in the documentation to avoid confusion when setting up a collection.