### PR TITLE
feat: look in .github and then root for the main config file

### DIFF
--- a/.github/workflows/auto_update_collections.yaml
+++ b/.github/workflows/auto_update_collections.yaml
@@ -3,8 +3,8 @@ on:
   workflow_call:
     inputs:
       config_file:
-        description: "Path to configuration file"
-        default: ".copilot-collections.yaml"
+        description: "Path to configuration file (searches .github/ then root if not specified)"
+        default: ""
         type: string
 
 permissions: {}
@@ -21,10 +21,44 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Find Config File
+        id: find-config
+        env:
+          INPUT_CONFIG_FILE: ${{ inputs.config_file }}
+        run: |
+          # Default locations to search (in order of preference)
+          CONFIG_LOCATIONS=(".github/.copilot-collections.yaml" ".copilot-collections.yaml")
+
+          if [ -n "$INPUT_CONFIG_FILE" ]; then
+            # User provided explicit path
+            if [ ! -f "$INPUT_CONFIG_FILE" ]; then
+              echo "::error::Configuration file not found: $INPUT_CONFIG_FILE"
+              exit 1
+            fi
+            CONFIG_FILE="$INPUT_CONFIG_FILE"
+          else
+            # Search through default locations
+            CONFIG_FILE=""
+            for loc in "${CONFIG_LOCATIONS[@]}"; do
+              if [ -f "$loc" ]; then
+                CONFIG_FILE="$loc"
+                break
+              fi
+            done
+
+            if [ -z "$CONFIG_FILE" ]; then
+              echo "::error::Configuration file not found. Searched in: ${CONFIG_LOCATIONS[*]}"
+              exit 1
+            fi
+          fi
+
+          echo "Using config file: $CONFIG_FILE"
+          echo "CONFIG_FILE=$CONFIG_FILE" >> $GITHUB_OUTPUT
+
       - name: Get Target Version
         id: config
         env:
-          CONFIG_FILE: ${{ inputs.config_file }}
+          CONFIG_FILE: ${{ steps.find-config.outputs.CONFIG_FILE }}
         run: |
           # Install yq if not available
           if ! command -v yq &> /dev/null; then
@@ -62,7 +96,7 @@ jobs:
         if: steps.upstream.outputs.UPDATE_NEEDED == 'true'
         env:
           LATEST_VERSION: ${{ steps.upstream.outputs.LATEST_VERSION }}
-          CONFIG_FILE: ${{ inputs.config_file }}
+          CONFIG_FILE: ${{ steps.find-config.outputs.CONFIG_FILE }}
         run: |
           yq -i ".copilot.version = \"$LATEST_VERSION\"" "$CONFIG_FILE"
 

--- a/README.md
+++ b/README.md
@@ -30,18 +30,24 @@ To add Copilot collections to your repository, follow these three steps.
 
 ### **1. Create the Configuration**
 
-Create a file named `.copilot-collections.yaml` in the root of your repository.
+Create a file named `.copilot-collections.yaml` in the `.github` folder of your repository (recommended) or in the repository root.
 
 ```yaml
-copilot:  
-  # The version of the toolkit to use (matches a Release Tag in this repo)  
-  version: "v1.0.0"  
-    
-  # The collections you want to install  
-  collections:  
-    - charm-python  
+copilot:
+  # The version of the toolkit to use (matches a Release Tag in this repo)
+  version: "v1.0.0"
+
+  # The collections you want to install
+  collections:
+    - charm-python
     - pfe-charms
 ```
+
+**Location Preference:** The workflow and sync script will search for the config file in this order:
+1. `.github/.copilot-collections.yaml` (recommended)
+2. `.copilot-collections.yaml` (root, for backwards compatibility)
+
+You can also specify a custom location - see below for details.
 
 ### **2. Run the Initial Sync (Local)**
 
@@ -49,6 +55,15 @@ You can sync the instructions immediately to your local machine to verify them.
 
 ```bash
 curl -sL https://raw.githubusercontent.com/canonical/copilot-collections/main/scripts/local_sync.sh | bash
+```
+
+To specify a custom config file location:
+```bash
+# Via command-line argument
+curl -sL https://raw.githubusercontent.com/canonical/copilot-collections/main/scripts/local_sync.sh | bash -s -- custom/path/.copilot-collections.yaml
+
+# Via environment variable
+COPILOT_CONFIG_FILE="custom/path/.copilot-collections.yaml" curl -sL https://raw.githubusercontent.com/canonical/copilot-collections/main/scripts/local_sync.sh | bash
 ```
 
 **Note:** This will generate files in .github/instructions/, .github/prompts/, and .github/skills/. Do not edit these files manually; they will be overwritten.
@@ -60,19 +75,20 @@ To ensure your repo stays up to date when the Toolkit releases new versions, add
 **File:** `.github/workflows/copilot-collections-update.yml`
 
 ```yaml
-name: Auto-Update Copilot Instructions  
-on:  
-  schedule:  
-    - cron: '0 9 * * 1' # Run every Monday at 09:00 UTC  
+name: Auto-Update Copilot Instructions
+on:
+  schedule:
+    - cron: '0 9 * * 1' # Run every Monday at 09:00 UTC
   workflow_dispatch:
 
-jobs:  
-  check-update:  
-    # Always pin to @main to get the latest logic, but the content version is controlled by your .yaml file  
-    uses: canonical/copilot-collections/.github/workflows/auto_update_collections.yaml@main  
-    with:  
-      config_file: ".copilot-collections.yaml"  
+jobs:
+  check-update:
+    # Always pin to @main to get the latest logic, but the content version is controlled by your .yaml file
+    uses: canonical/copilot-collections/.github/workflows/auto_update_collections.yaml@main
     secrets: inherit
+    # Optionally specify a custom config file location:
+    # with:
+    #   config_file: "custom/path/.copilot-collections.yaml"
 ```
 
 ## **Inspiration & Credits**


### PR DESCRIPTION
To help keep the top level of repositories cleaner, and also since GitHub Copilot related files are logically located in `.github`, look for the `.copilot-collections.yaml` file in the `.github` folder. For backwards compatibility, then look in the project root as well.

* Adjusts the behaviour of the auto update workflow to be as described above, still allowing users to provide a custom location.
* Adjusts the behaviour of the local_sync script to be as described above, and adds the ability to provide a custom location to be consistent with the workflow (either via an environment variable or argument)
* Update the README to match - there's also a bit of automated trailing whitespace cleanup

Fixes #13