### PR TITLE
Add instructions related to internal references

### DIFF
--- a/assets/instructions/documentation/documentation-rtd.instructions.md
+++ b/assets/instructions/documentation/documentation-rtd.instructions.md
@@ -47,6 +47,45 @@ Adhere to the following conventions:
 - Use admonitions sparingly in the documentation. Offer suggestions to remove admonitions when they are not necessary (for example, if the text is not necessary for the user to read). 
 - Only use the following types: `note`, `tip`, `warning`, `important`
 
+## Internal references
+
+When adding a reference to a document in the RTD project, use a target contained in the document. 
+The document's target should be defined at the top of the document. 
+
+The target is defined like this for `*.md` files:
+
+```
+(target_ID)=
+
+# Title of document
+```
+
+To reference a target in a `*md` file, use the following syntax: 
+
+```
+{ref}`Link text <target_ID>`
+```
+
+In `*.rst` files, the targets are defined like this:
+
+```
+.. _target_ID:
+
+Title of document
+=================
+```
+
+To reference a target in a `*.rst` file, use the following syntax:
+
+```
+:ref:`Link text <target_ID>`
+```
+
+Adhere to the following conventions:
+
+- Never use paths when referencing another document. Always use targets. If there is no existing target, add one.
+- If you want to reference a specific section within a document, add the target directly above the relevant section and use that target when creating the reference.
+
 ## Small-edit rules for AI agents
 
 - Do not change `docs/index.md` structure without updating the `toctree` directive — keep the order and paths in sync with files under `docs/`.


### PR DESCRIPTION
Based on conversations in https://github.com/canonical/falco-operators/pull/58 

This PR adds instructions and guidelines for handling internal references in RTD projects.