### PR TITLE
Add Generic and RTD documentation collections.

### DIFF
--- a/collections.yaml
+++ b/collections.yaml
@@ -76,3 +76,21 @@ charm-python:
     - core
     - common-python
   items: []
+
+documentation-generic:
+  description: "Generic Documentation standards"
+  includes:
+    - core
+    - common-documentation
+  items:
+    - src: assets/instructions/documentation/documentation.instructions.md
+      dest: .github/instructions/documentation.instructions.md
+
+documentation-rtd:
+  description: "Read the Docs Specific Documentation"
+  includes:
+    - core
+    - common-documentation
+  items:
+    - src: assets/instructions/documentation/documentation-rtd.instructions.md
+      dest: .github/instructions/documentation-rtd.instructions.md


### PR DESCRIPTION
Decouple "common-documentation" from Generic standards.

The Generic documentation standards make references to "charms" and "juju" which are not applicable to all teams and repos.
By decoupling the "common-documentation" collection from the standards, documentation-focused collections are more flexible and include only the instructions for that specific type of documentation.