### PR TITLE
feat(skills): add secret-guard skill and core instruction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ __pycache__/
 *.egg-info/
 .pytest_cache/
 venv/
+.venv/
 env/
 
 # Node.js

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ We highly encourage you to explore it for further inspiration, including advance
   * `instructions/`: Custom instruction files.
   * `prompts/`: Prompt files.
   * `agents/`: Agent files.
-* `skills/`: Core agent skill directories (each containing `SKILL.md`).
+* `skills/`: Core agent skill directories (each containing `SKILL.md`, plus optional `scripts/` and `references/` subfolders).
 * `collections.yaml`: Core definitions.
 * `groups/`: Team specific collections.
   * `<team-name>/`: Folder for team assets.
@@ -160,6 +160,25 @@ We highly encourage you to explore it for further inspiration, including advance
    **Important:** Skills are directories, so `dest` must end with `/`.
 4. **Validate:** Run `./scripts/validate_collections.sh .`
 5. **Release:** Follow the same release process as instructions.
+
+#### **Skill Directory Layout (optional subfolders)**
+
+A skill is a directory whose only required file is `SKILL.md`. Because skills are
+synced as whole directories, any supporting files you place alongside `SKILL.md`
+are copied automatically — you do **not** register them individually in the manifest.
+
+Two optional subfolders are used by convention across existing skills:
+
+* `scripts/`: Executable helpers the skill invokes (e.g. Python utilities).
+  Referenced from `SKILL.md` by relative path (e.g. `python3 scripts/helper.py`).
+  Examples: `generate-agent-skills/scripts/`, `generate-path-instructions/scripts/`.
+* `references/`: Auxiliary Markdown the agent loads on demand (checklists,
+  templates, deep-dive docs) to keep `SKILL.md` lean.
+  Examples: `generate-agent/references/`, `generate-repo-instructions/references/`.
+
+Both are optional; add them only when the skill needs helper code or extra
+reference material. Note: files under `skills/**` are exempt from the license
+header check (see `.licenserc.yaml`).
 
 ### **Group Collections**
 

--- a/assets/instructions/common/secret-guard.instructions.md
+++ b/assets/instructions/common/secret-guard.instructions.md
@@ -1,0 +1,17 @@
+---
+applyTo: '**'
+description: 'Prevent secrets (API keys, tokens, passwords, private keys) from leaking into context, tool output, or spawned processes.'
+---
+
+## Secret Handling (Always On)
+
+These rules protect secrets at all times. They are subordinate only to an explicit, direct user command.
+
+-   **Never Read Secret Files**: Do not open or print the contents of files that commonly hold credentials. This includes `.env`, `.env.*`, `.netrc`, `.npmrc`, `.pypirc`; any `.pem`, `.key`, `.p12`, `.pfx`, `.crt`, `.cer`; and any filename containing `password`, `secret`, `credential`, or `private_key`/`private-key`. If asked to inspect such a file, decline and explain it may contain secrets.
+-   **Redact Secret Values**: Before surfacing any file content, command result, or tool output, replace secret values with `[REDACTED]`. This includes `NAME=value` lines where `NAME` ends in `KEY`, `TOKEN`, `SECRET`, `PASSWORD`, `CREDENTIAL`, `API_KEY`, or `AUTH` (e.g. `CLOUD_API_KEY=sk-abc123` → `CLOUD_API_KEY=[REDACTED]`).
+-   **Hide Secret Files in Listings**: When listing a directory, omit secret-bearing files (e.g. `.env*`, `.netrc`, `.npmrc`, `.pypirc`) rather than revealing their existence.
+-   **Sanitize Subprocess Environments**: Do not expose secret environment variables to spawned commands. Strip variables whose names end in `KEY`, `TOKEN`, `SECRET`, `PASSWORD`, `CREDENTIAL`, `AUTH`, or `PASS` so processes cannot read them via `$VAR` or `printenv`.
+-   **Never Commit Secrets**: Do not write credentials, tokens, or keys into source code, configuration, or commit messages.
+-   **Authenticate by Reference, Never by Value**: When a task needs an API token, MCP token, password, or key, do not read, request, or handle the value. Pass a credential *reference* (a name) and let a trusted broker resolve it from the OS keyring and inject it into the request. If no keyring entry exists, ask the user to store it themselves (e.g. `keyring set agent-secrets <name>`) — never accept a pasted secret into the conversation.
+
+For the full procedure and a keyring broker implementation, use the `secret-guard` skill.

--- a/collections.yaml
+++ b/collections.yaml
@@ -14,6 +14,8 @@ core:
       dest: .github/instructions/instructions.instructions.md
     - src: assets/instructions/common/core-directive.instructions.md
       dest: .github/instructions/core-directive.instructions.md
+    - src: assets/instructions/common/secret-guard.instructions.md
+      dest: .github/instructions/secret-guard.instructions.md
 
 common-go:
   description: "Go development standards and reviewer agent"
@@ -66,6 +68,8 @@ copilot-toolkit:
       dest: .github/skills/migrate-harness-tests-to-state-transition-test/
     - src: skills/retrospective-artifacts
       dest: .github/skills/retrospective-artifacts/
+    - src: skills/secret-guard
+      dest: .github/skills/secret-guard/
 
 # ==========================================
 # 2. Framework Specifics

--- a/skills/secret-guard/SKILL.md
+++ b/skills/secret-guard/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: secret-guard
+description: Lets an agent authenticate to APIs and MCP servers WITHOUT ever seeing secret values. Use whenever a task needs an API token, MCP token, password, or key. The agent passes a credential *reference* (a name); a trusted non-LLM broker resolves it from the OS keyring, injects it into the request, scrubs the response, and returns only scrubbed output. The secret value never enters the agent's context or the LLM.
+---
+
+# Secret Guard
+
+## Core Principle
+
+**You never possess a secret value. You only pass references (names).**
+
+A secret must never enter the model's context window. Do not read secret files, do not print values, do not reconstruct them. To authenticate, you emit a credential *reference* by name and let a trusted, non-LLM broker resolve→inject→scrub. This is architectural, not advisory: the value stays inside the broker process and is never returned to you.
+
+Secrets live in the **OS keyring** (Keychain / libsecret / Windows Credential Manager). They are stored out-of-band by a human, e.g.:
+
+```
+keyring set agent-secrets github_token
+keyring set agent-secrets openai_api_key
+```
+
+You reference them by name only — e.g. `github_token`. You never see the value.
+
+---
+
+## Mechanism (a): Resolve-and-Inject — PRIMARY
+
+Use this for **all API and MCP token** use. The broker resolves the named
+credential, injects it into the request header, performs the call, scrubs the
+response, and returns only the scrubbed body. The secret exists only inside the
+broker process for the duration of one request.
+
+```bash
+python3 scripts/keyring_broker.py request \
+    --name github_token \
+    --url https://api.github.com/user \
+    --header "Authorization: Bearer {secret}"
+```
+
+- `--name` is a **reference**, never a value.
+- `{secret}` is a placeholder the broker fills internally; you never type the token.
+- Output is scrubbed before you see it.
+
+**For MCP servers:** put the credential in the **MCP server's** environment/config,
+resolved by the client runtime — never in tool arguments, conversation, or files.
+Prefer OAuth flows where the server holds the token and the client gets a
+short-lived, scoped handle. Use `${input:...}`/env indirection so no literal
+appears in committed config.
+
+---
+
+## Mechanism (b): Env-Injecting Exec — DISCOURAGED FALLBACK
+
+Only when a legacy CLI can read a credential **solely** from its environment and
+(a) is impossible. The broker injects the value into a **single child process's**
+environment (never yours), runs one command, and scrubs its output.
+
+```bash
+python3 scripts/keyring_broker.py exec \
+    --name aws_secret_access_key \
+    --env-var AWS_SECRET_ACCESS_KEY \
+    -- aws s3 ls
+```
+
+**Why discouraged:** the value lives in the child's `/proc/<pid>/environ` for the
+process lifetime and is exposed to any subprocess it spawns and to verbose/debug
+output you cannot fully control. Scope it to one invocation; never persist it;
+never export it into your own shell.
+
+---
+
+## Never-Do (hard rules)
+
+- ❌ Read `.env`, `.env.*`, `.netrc`, `.npmrc`, `.pypirc`, `*.pem`, `*.key`, `id_rsa`, `credentials`, `kubeconfig`, `.git-credentials`, or any `*secret*`/`*credential*`/`*password*` file to "get the token". Decline and use the broker.
+- ❌ Ask the user to paste a secret into the conversation.
+- ❌ Put a secret in a tool argument, URL query string, commit, log, or file.
+- ❌ Echo, encode, or transform a value to move it past scrubbing.
+- ❌ Export a resolved secret into your own environment or a persistent shell.
+
+## Always-Do
+
+- ✅ Reference credentials by **name**; let the broker resolve them.
+- ✅ Prefer mechanism (a); treat (b) as a last resort scoped to one command.
+- ✅ Use **short-lived, narrowly-scoped** tokens so any leak has minimal blast radius.
+- ✅ Rely on the broker's scrubbing for all returned output.
+- ✅ If a secret is unavoidable and no keyring entry exists, ask the user to run
+     `keyring set agent-secrets <name>` themselves — never handle the value yourself.
+
+---
+
+## Defense in Depth (environment expectations)
+
+These are enforced outside the model and assumed by this skill:
+
+- The agent process runs with a **sanitized environment** (no secret env vars).
+- An **egress allowlist** limits where tokens can be sent.
+- Every credential **use** is audited **by name** — values are never logged.
+
+## Reference Implementation
+
+`scripts/keyring_broker.py` implements both mechanisms. The secret value is never
+written to stdout/stderr, never logged, and never returned to the caller.

--- a/skills/secret-guard/scripts/keyring_broker.py
+++ b/skills/secret-guard/scripts/keyring_broker.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""keyring_broker.py — resolve-and-inject secret broker for agents/LLMs.
+
+Design goal: an agent (or the LLM driving it) NEVER sees a secret value.
+The agent passes a credential *reference* (a name). This trusted, non-LLM
+layer resolves the value from the OS keyring, injects it into an outbound
+request or a single child process, scrubs the result, and returns ONLY the
+scrubbed output plus a status. The secret value is never printed, logged,
+or returned.
+
+Two mechanisms:
+
+  (a) request   — PRIMARY. Resolve a named credential, inject it into an
+                  HTTP request header, perform the request, scrub the
+                  response, and return the scrubbed body. The secret exists
+                  only inside this process, only for the duration of the call.
+
+  (b) exec      — DISCOURAGED FALLBACK. For legacy CLIs that can only read a
+                  secret from their environment. Inject the resolved value
+                  into a SINGLE child process's environment (never the
+                  agent's), run one command, scrub its output. Use only when
+                  (a) is impossible. Wider exposure: the value lives in the
+                  child's /proc/<pid>/environ for the process lifetime.
+
+Secrets are stored in the OS keyring (Keychain / libsecret / Windows
+Credential Manager) via the `keyring` library. Store them out-of-band, e.g.:
+
+    keyring set agent-secrets github_token
+    keyring set agent-secrets openai_api_key
+
+The agent then references them by name only: `github_token`.
+
+CLI:
+    keyring_broker.py request --name github_token \
+        --url https://api.github.com/user \
+        --header "Authorization: Bearer {secret}"
+
+    keyring_broker.py exec --name aws_secret_access_key \
+        --env-var AWS_SECRET_ACCESS_KEY -- aws s3 ls
+
+Exit code 0 on success. The secret value is never emitted on any stream.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import urllib.request
+
+SERVICE = os.environ.get("AGENT_KEYRING_SERVICE", "agent-secrets")
+
+# Names whose VALUES must never be printed back to the agent/LLM.
+_SECRET_NAME_RE = re.compile(
+    r"(?i)[\w-]*(KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|AUTH|PASS)$"
+)
+_ENV_VAR_LINE_RE = re.compile(
+    r"(?i)^([\w.-]*(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|API_KEY|AUTH)\s*[:=]\s*)\S+",
+    re.MULTILINE,
+)
+
+
+def _resolve(name: str) -> str:
+    """Fetch a secret value from the OS keyring by reference. Never returned to caller."""
+    try:
+        import keyring
+    except ImportError:
+        sys.exit("error: the 'keyring' package is required (pip install keyring)")
+    value = keyring.get_password(SERVICE, name)
+    if value is None:
+        sys.exit(
+            f"error: no credential named '{name}' in keyring service '{SERVICE}'. "
+            f"Store it with: keyring set {SERVICE} {name}"
+        )
+    return value
+
+
+def scrub(text: str, secret: str) -> str:
+    """Remove the literal secret and secret-looking VAR=value lines from text."""
+    if secret:
+        text = text.replace(secret, "[REDACTED]")
+        # Defeat trivial transforms that would otherwise slip a value through.
+        import base64
+
+        try:
+            text = text.replace(base64.b64encode(secret.encode()).decode(), "[REDACTED]")
+        except Exception:
+            pass
+    text = _ENV_VAR_LINE_RE.sub(r"\1[REDACTED]", text)
+    return text
+
+
+def cmd_request(args: argparse.Namespace) -> int:
+    """(a) Resolve a named credential and inject it into an HTTP request."""
+    secret = _resolve(args.name)
+    headers = {}
+    for raw in args.header or []:
+        if ":" not in raw:
+            sys.exit(f"error: malformed --header (want 'Name: value'): {raw!r}")
+        key, _, val = raw.partition(":")
+        headers[key.strip()] = val.strip().replace("{secret}", secret)
+
+    data = args.data.encode() if args.data else None
+    req = urllib.request.Request(
+        args.url, data=data, headers=headers, method=args.method
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=args.timeout) as resp:
+            body = resp.read().decode(errors="replace")
+            status = resp.status
+    except urllib.error.HTTPError as e:
+        body = e.read().decode(errors="replace")
+        status = e.code
+    except Exception as e:
+        # Never let an exception echo the injected header/secret.
+        sys.exit(f"error: request failed: {type(e).__name__}")
+
+    sys.stdout.write(scrub(body, secret))
+    sys.stderr.write(f"[keyring_broker] {args.method} {args.url} -> {status}\n")
+    return 0 if status < 400 else 1
+
+
+def cmd_exec(args: argparse.Namespace) -> int:
+    """(b) DISCOURAGED: inject a named credential into one child process's env."""
+    secret = _resolve(args.name)
+    child_env = {
+        k: v for k, v in os.environ.items() if not _SECRET_NAME_RE.search(k)
+    }
+    child_env[args.env_var] = secret
+    try:
+        proc = subprocess.run(
+            args.command,
+            env=child_env,
+            capture_output=True,
+            text=True,
+            timeout=args.timeout,
+        )
+    except Exception as e:
+        sys.exit(f"error: exec failed: {type(e).__name__}")
+
+    sys.stdout.write(scrub(proc.stdout, secret))
+    sys.stderr.write(scrub(proc.stderr, secret))
+    return proc.returncode
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    sub = p.add_subparsers(dest="mode", required=True)
+
+    r = sub.add_parser("request", help="(a) inject credential into an HTTP request")
+    r.add_argument("--name", required=True, help="credential reference name")
+    r.add_argument("--url", required=True)
+    r.add_argument(
+        "--header",
+        action="append",
+        help="header 'Name: value'; use {secret} placeholder for the value",
+    )
+    r.add_argument("--method", default="GET")
+    r.add_argument("--data", help="request body (no secrets here)")
+    r.add_argument("--timeout", type=float, default=30.0)
+    r.set_defaults(func=cmd_request)
+
+    e = sub.add_parser("exec", help="(b) DISCOURAGED: inject credential into a child env")
+    e.add_argument("--name", required=True, help="credential reference name")
+    e.add_argument("--env-var", required=True, help="env var name to expose to the child")
+    e.add_argument("--timeout", type=float, default=120.0)
+    e.add_argument("command", nargs=argparse.REMAINDER, help="-- command to run")
+    e.set_defaults(func=cmd_exec)
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.mode == "exec" and args.command and args.command[0] == "--":
+        args.command = args.command[1:]
+    if args.mode == "exec" and not args.command:
+        sys.exit("error: no command given after '--'")
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a **secret-guard** skill that lets agents authenticate to APIs and MCP servers **without ever seeing secret values**. The agent passes credential *references* (names); a trusted non-LLM broker resolves them from the OS keyring, injects them into the request, scrubs the response, and returns only scrubbed output.

## What's included

- **`skills/secret-guard/`** (registered under the `copilot-toolkit` collection)
  - `SKILL.md` — teaches the reference-only model: never possess a secret value, only pass names.
  - `scripts/keyring_broker.py` — implements two mechanisms:
    - **(a) resolve-and-inject** (primary): resolves a named credential, injects it into an HTTP header, scrubs the response. The secret lives only in-process for one request.
    - **(b) env-injecting exec** (discouraged fallback): injects into a single child process's env for legacy CLIs that can only read env vars.
- **`assets/instructions/common/secret-guard.instructions.md`** (core, `applyTo: '**'`) — always-on baseline: authenticate by reference, never read secret files, redact values, sanitize subprocess envs.
- **README** — documents the optional `scripts/` and `references/` skill subfolders (previously undocumented despite being used by several skills).
- **`.gitignore`** — ignore `.venv/` created by `make lint-md`.

## Rationale

The naive approach (read `.env`, then redact) is self-defeating — you must possess a secret to redact it, and regex redaction is trivially bypassed by encoding. This design instead makes it *architecturally impossible* for the secret to enter the model's context: a trusted layer does resolve → inject → scrub.

## Validation

- `./scripts/validate_collections.sh .` ✅
- `./tests/test_validate.sh` ✅
- `./tests/test_install.sh` ✅
- `make lint-md` on new/changed markdown ✅
- Secret scan on the diff ✅ (no secrets)

## Notes

- No version bump — a release tag is expected post-merge per the README release process.