### PR TITLE
docs: fix update workflow permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ on:
   schedule:
     - cron: '0 9 * * 1' # Run every Monday at 09:00 UTC
   workflow_dispatch:
+  
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   check-update:


### PR DESCRIPTION
The permissions required need to be broader than what child workflows get by default.

See: https://github.com/canonical/snapcraft/actions/runs/29241317562