### PR TITLE
feat(workflow): allow overriding the auto-update branch name

### DIFF
--- a/.github/workflows/auto_update_collections.yaml
+++ b/.github/workflows/auto_update_collections.yaml
@@ -6,6 +6,10 @@ on:
         description: "Path to configuration file (searches .github/ then root if not specified)"
         default: ""
         type: string
+      branch_name:
+        description: "Branch name used for the update pull request"
+        default: "chore/auto-copilot-collections"
+        type: string
 
 permissions: {}
 
@@ -113,7 +117,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: update Copilot collections to ${{ steps.upstream.outputs.LATEST_VERSION }}"
-          branch-name: "chore/auto-copilot-collections"
+          branch-name: "${{ inputs.branch_name }}"
           title: "chore: update Copilot collections to ${{ steps.upstream.outputs.LATEST_VERSION }}"
           body: "Update to version `${{ steps.upstream.outputs.LATEST_VERSION }}`."
           upsert: true

--- a/README.md
+++ b/README.md
@@ -102,9 +102,10 @@ jobs:
     # Always pin to @main to get the latest logic, but the content version is controlled by your .yaml file
     uses: canonical/copilot-collections/.github/workflows/auto_update_collections.yaml@main
     secrets: inherit
-    # Optionally specify a custom config file location:
+    # Optionally specify a custom config file location and/or branch name:
     # with:
     #   config_file: "custom/path/.copilot-collections.yaml"
+    #   branch_name: "work/bot/update-copilot-collections"
 ```
 
 ## **Inspiration & Credits**


### PR DESCRIPTION
## Summary
- add a new reusable workflow input branch_name with a default matching current behavior
- use inputs.branch_name for the PR branch in .github/workflows/auto_update_collections.yaml
- document the new input in README with a Starcraft-compatible branch naming example

Fixes #59