### PR TITLE
(WIP) feat: Skills for documentation Spread tests

### DIFF
--- a/collections.yaml
+++ b/collections.yaml
@@ -76,6 +76,10 @@ copilot-toolkit:
       dest: .github/skills/retrospective-artifacts/
     - src: skills/secret-guard
       dest: .github/skills/secret-guard/
+    - src: skills/generate-docs-spread-test
+      dest: .github/skills/generate-docs-spread-test/
+    - src: skills/prepare-docs-automated-spread-test
+      dest: .github/skills/prepare-docs-automated-spread-test/
 
 # ==========================================
 # 2. Framework Specifics

--- a/skills/generate-docs-spread-test/SKILL.md
+++ b/skills/generate-docs-spread-test/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: generate-docs-spread-test
+description: "Regenerate Spread tutorial test scaffolding from docs/tutorial.md. Creates spread.yaml, tests/spread/tutorial/task.yaml, and .github/workflows/spread_test.yaml. WHEN: generate spread test, create task.yaml, spread scaffolding, refresh spread test, tutorial spread task, spread tutorial test."
+argument-hint: "Describe any constraints or the target tutorial file"
+---
+
+# Generate the tutorial Spread test
+
+You are refreshing the Spread test scaffolding for a charm tutorial.
+The tutorial lives in `docs/tutorial.md` and is the single source of truth for
+the commands that must run.
+
+## When to Use
+
+- Generating or refreshing Spread test scaffolding from a charm tutorial
+- Creating `spread.yaml`, `tests/spread/tutorial/task.yaml`, and the CI workflow
+- Extracting tutorial commands into Spread lifecycle phases (prepare/execute/restore)
+
+## Goal
+
+Add or update exactly these three files:
+
+1. `spread.yaml` — Spread project configuration at the repository root.
+2. `tests/spread/tutorial/task.yaml` — the tutorial task, one Spread task
+   covering the full deploy-to-cleanup flow.
+3. `.github/workflows/spread_test.yaml` — a plain (non-agentic) GitHub Actions
+   workflow that installs Spread and runs `spread -v github-ci:` on
+   `workflow_dispatch`, on a weekly `schedule`, and on `pull_request` when any
+   of the Spread files change.
+
+Do **not** modify any other file. Do not touch `docs/tutorial.md`, `src/**`,
+`lib/**`, or any existing workflow.
+
+## Procedure
+
+### Step 1 — Read the tutorial
+
+Read `docs/tutorial.md` end-to-end. Also read `charmcraft.yaml` or
+`metadata.yaml` to discover the charm name.
+
+### Step 2 — Extract and classify commands
+
+Extract shell commands from `docs/tutorial.md` in tutorial order. Do not
+paraphrase or reorder them. Split commands across Spread lifecycle phases:
+
+Refer to [the command classification reference](./references/command-classification.md)
+for the phase assignment criteria and examples.
+
+### Step 3 — Generate `spread.yaml`
+
+Refer to [the spread.yaml reference](./references/spread-yaml-shape.md) for
+the required structure, including the verbatim `github-ci` backend block.
+
+### Step 4 — Generate `tests/spread/tutorial/task.yaml`
+
+Refer to [the task.yaml reference](./references/task-yaml-shape.md) for
+the required structure. Replace narrative waits with deterministic checks
+using `juju wait-for` and Spread's `MATCH` helper.
+
+### Step 5 — Generate `.github/workflows/spread_test.yaml`
+
+Refer to [the workflow reference](./references/spread-workflow-shape.md) for
+the required structure.
+
+### Step 6 — Validate
+
+Run each check. If any fails, fix the generated files and re-run.
+
+1. Install `spread` if missing:
+   ```
+   command -v spread || sudo snap install spread || \
+     (sudo snap install --classic go && /snap/bin/go install github.com/canonical/spread/cmd/spread@latest)
+   ```
+2. `spread -list ./` — must succeed and print at least one job matching
+   `github-ci:ubuntu-24.04-64:tests/spread/tutorial…`.
+3. `yamllint spread.yaml tests/spread/tutorial/task.yaml .github/workflows/spread_test.yaml`
+   — must pass.
+
+### Step 7 — Summarize
+
+Provide the user with:
+
+1. **Command mapping** — a Markdown table with columns `Tutorial section` |
+   `Phase (prepare / execute / restore)` | `Command` covering every
+   command extracted from the tutorial.
+2. **Validation output** — trimmed `spread -list ./` output.
+3. **Follow-ups** — anything the tutorial doesn't yet express as a
+   deterministic check (e.g., manual "click Sign Up" steps that had to be
+   dropped or approximated).

--- a/skills/generate-docs-spread-test/SKILL.md
+++ b/skills/generate-docs-spread-test/SKILL.md
@@ -2,6 +2,9 @@
 name: generate-docs-spread-test
 description: "Regenerate Spread tutorial test scaffolding from docs/tutorial.md. Creates spread.yaml, tests/spread/tutorial/task.yaml, and .github/workflows/spread_test.yaml. WHEN: generate spread test, create task.yaml, spread scaffolding, refresh spread test, tutorial spread task, spread tutorial test."
 argument-hint: "Describe any constraints or the target tutorial file"
+metadata:
+  author: canonical/platform-engineering
+  version: "1.0.0"
 ---
 
 # Generate the tutorial Spread test

--- a/skills/generate-docs-spread-test/references/command-classification.md
+++ b/skills/generate-docs-spread-test/references/command-classification.md
@@ -1,0 +1,52 @@
+# Command Classification by Spread Phase
+
+Extract shell commands from `docs/tutorial.md` in tutorial order. Do not
+paraphrase or reorder them. Assign each command to one of these Spread
+lifecycle phases:
+
+## Project-level `prepare:`
+
+Cluster bootstrap that must run once before the task:
+
+- `snap install --classic concierge`
+- `concierge prepare -p microk8s`
+- `microk8s enable ingress`
+- `juju add-model <model-name>`
+- Add hostnames to `/etc/hosts`
+
+## Task `execute:`
+
+The tutorial's deploy chain, integrate chain, config steps, wait-for-active
+checks, and smoke tests:
+
+- `juju deploy` commands
+- `juju integrate` commands
+- `juju config` commands
+- `juju deploy nginx-ingress-integrator` (or equivalent ingress)
+- `juju trust ... --scope cluster` when RBAC is enabled (make unconditional)
+- `juju integrate <app> nginx-ingress-integrator`
+- Wait for Active — replace narrative waits with deterministic checks:
+  `juju wait-for application <app> --query='status=="active"' --timeout=30m`
+  for each deployed application
+- HTTP smoke check — use Spread's `MATCH` helper:
+  `curl -sSf http://<hostname> | MATCH "<expected marker>"`
+
+## Task `restore:`
+
+Cleanup that undoes the task's effects:
+
+- `juju destroy-model <model-name> --no-prompt --destroy-storage=true || true`
+- Revert `/etc/hosts` changes if prepare made them
+- No VM teardown — `github-ci` runs on the runner itself
+
+## Spread quick reference
+
+- Cascade order: `project` → `backend` → `system` → `suite` → `task`. Each
+  level may set `environment`, `prepare`, `restore`, `prepare-each`,
+  `restore-each`, `debug`, and `debug-each`.
+- Helpers available inside scripts:
+  `MATCH` (assert stdin matches a pattern), `NOMATCH` (assert it doesn't),
+  `ERROR` (fail with a message), `FATAL` (fail without retry — adhoc only).
+- `path:` sets the remote base directory the project is uploaded into.
+- `exclude:` filters out repo files that should not be shipped to the system.
+- `kill-timeout:` bounds task/suite execution.

--- a/skills/generate-docs-spread-test/references/spread-workflow-shape.md
+++ b/skills/generate-docs-spread-test/references/spread-workflow-shape.md
@@ -1,0 +1,54 @@
+# Target `.github/workflows/spread_test.yaml` Shape
+
+## Required structure
+
+```yaml
+# Copyright <year> Canonical Ltd.
+# See LICENSE file for licensing details.
+name: Spread tutorial test
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1"
+  pull_request:
+    paths:
+      - spread.yaml
+      - tests/spread/**
+      - .github/workflows/spread_test.yaml
+
+permissions:
+  contents: read
+
+jobs:
+  spread:
+    runs-on: [self-hosted, linux, edge]
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Spread
+        run: |
+          sudo snap install spread || {
+            sudo snap install --classic go
+            /snap/bin/go install github.com/canonical/spread/cmd/spread@latest
+            echo "$HOME/go/bin" >> "$GITHUB_PATH"
+          }
+      - name: Run Spread
+        run: spread -v github-ci:
+      - name: Upload Spread logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: spread-logs
+          path: |
+            .spread-reuse.yaml
+            /tmp/spread-*
+          if-no-files-found: ignore
+```
+
+## Key rules
+
+- **Runner label**: Must use `runs-on: [self-hosted, linux, edge]` to match
+  existing workflows in the repository.
+- **Triggers**: `workflow_dispatch`, weekly `schedule`, and `pull_request`
+  filtered to Spread-related paths.

--- a/skills/generate-docs-spread-test/references/spread-yaml-shape.md
+++ b/skills/generate-docs-spread-test/references/spread-yaml-shape.md
@@ -1,0 +1,62 @@
+# Target `spread.yaml` Shape
+
+Derive the charm name from `charmcraft.yaml` or `metadata.yaml` (`name:` field).
+
+## Required structure
+
+```yaml
+# Copyright <year> Canonical Ltd.
+# See LICENSE file for licensing details.
+project: <charm-name>
+path: /<charm-name>
+kill-timeout: 90m
+
+environment:
+  PROJECT_PATH: /<charm-name>
+  SUDO_USER: ""
+  SUDO_UID: ""
+  LANG: "C.UTF-8"
+  LANGUAGE: "en"
+
+exclude:
+  - .git
+  - .github
+  - .tox
+  - .venv
+  - .*_cache
+  - charmcraft
+
+backends:
+  github-ci:
+    type: adhoc
+    allocate: |
+      echo "Allocating ad-hoc $SPREAD_SYSTEM"
+      if [ -z "${GITHUB_RUN_ID:-}" ]; then
+        FATAL "this back-end only works inside GitHub CI"
+        exit 1
+      fi
+      echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/99-spread-users
+      ADDRESS localhost:22
+    discard: |
+      echo "Discarding ad-hoc $SPREAD_SYSTEM"
+    systems:
+      - ubuntu-24.04-64:
+          username: ubuntu
+          password: ubuntu
+          workers: 1
+
+suites:
+  tests/spread/:
+    summary: <Charm-name> charm tutorial test
+    systems:
+      - ubuntu-24.04-64
+    prepare: |
+      # Bootstrap concierge, MicroK8s, Juju, model, /etc/hosts.
+      # Use the commands from docs/tutorial.md.
+    restore: |
+      # Undo /etc/hosts change if prepare made it.
+```
+
+The `github-ci` backend block above must be used **verbatim** (from
+`canonical/operator-workflows/spread.yaml`). Do not invent an LXD, Multipass,
+or QEMU backend.

--- a/skills/generate-docs-spread-test/references/task-yaml-shape.md
+++ b/skills/generate-docs-spread-test/references/task-yaml-shape.md
@@ -1,0 +1,36 @@
+# Target `tests/spread/tutorial/task.yaml` Shape
+
+## Required structure
+
+```yaml
+# Copyright <year> Canonical Ltd.
+# See LICENSE file for licensing details.
+summary: Deploy <charm-name> end-to-end following docs/tutorial.md
+kill-timeout: 60m
+execute: |
+  # 1. juju deploy chain (e.g. postgresql-k8s --trust, redis-k8s, main app).
+  # 2. juju integrate chain.
+  # 3. juju config commands.
+  # 4. juju deploy ingress; juju trust ... --scope cluster if RBAC.
+  # 5. juju integrate <app> <ingress>.
+  # 6. juju wait-for application <app> --query='status=="active"' --timeout=30m
+  #    for each deployed application.
+  # 7. curl -sSf http://<hostname> | MATCH "<expected marker>".
+restore: |
+  juju destroy-model <model-name> --no-prompt --destroy-storage=true || true
+```
+
+## Key rules
+
+- **Verbatim commands**: Extract shell commands from `docs/tutorial.md` in
+  tutorial order. Do not paraphrase or reorder them.
+- **Deterministic waits**: Replace narrative "wait until Active" with
+  `juju wait-for application <app> --query='status=="active"' --timeout=30m`
+  for each deployed application.
+- **HTTP smoke check**: Use Spread's `MATCH` helper:
+  `curl -sSf http://<hostname> | MATCH "<expected marker>"`.
+- **Channels**: Match channels from the project's integration test workflow
+  (e.g., `.github/workflows/integration_test.yaml`). Let `concierge` handle
+  the install unless the tutorial specifies channels explicitly.
+- **RBAC trust**: Make `juju trust ... --scope cluster` unconditional in
+  the task (it's a no-op when RBAC is disabled).

--- a/skills/prepare-docs-automated-spread-test/SKILL.md
+++ b/skills/prepare-docs-automated-spread-test/SKILL.md
@@ -2,6 +2,9 @@
 name: prepare-docs-automated-spread-test
 description: "Prepare a charm tutorial for the canonical/operator-workflows automated documentation Spread test. Adds SPREAD / SPREAD SKIP annotations to docs/tutorial.md, generates a top-level spread.yaml, and creates .github/workflows/spread_docs.yaml. WHEN: prepare spread docs, annotate tutorial for spread, create spread yaml, add spread workflow, automate tutorial testing, spread test setup, docs spread."
 argument-hint: "Describe the target repository or any specific constraints"
+metadata:
+  author: canonical/platform-engineering
+  version: "1.0.0"
 ---
 
 # Prepare the tutorial for the automated documentation Spread workflow

--- a/skills/prepare-docs-automated-spread-test/SKILL.md
+++ b/skills/prepare-docs-automated-spread-test/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: prepare-docs-automated-spread-test
+description: "Prepare a charm tutorial for the canonical/operator-workflows automated documentation Spread test. Adds SPREAD / SPREAD SKIP annotations to docs/tutorial.md, generates a top-level spread.yaml, and creates .github/workflows/spread_docs.yaml. WHEN: prepare spread docs, annotate tutorial for spread, create spread yaml, add spread workflow, automate tutorial testing, spread test setup, docs spread."
+argument-hint: "Describe the target repository or any specific constraints"
+---
+
+# Prepare the tutorial for the automated documentation Spread workflow
+
+You are preparing this repository to use
+`canonical/operator-workflows/.github/workflows/docs_spread.yaml@main`, the
+reusable workflow that runs a Spread test over a Markdown documentation file.
+
+This skill is **repository-agnostic**. Do not hard-code application names,
+model names, hostnames, or commands drawn from any specific charm. Read
+`docs/tutorial.md` in the target repository and make your own decisions.
+
+## When to Use
+
+- Setting up automated Spread testing for a charm tutorial
+- Annotating `docs/tutorial.md` with `SPREAD` / `SPREAD SKIP` comments
+- Generating `spread.yaml` and `.github/workflows/spread_docs.yaml`
+- Onboarding a charm repository to the `canonical/operator-workflows` docs Spread workflow
+
+## Goal
+
+Add or update **only** these three files:
+
+1. `docs/tutorial.md` — annotated with `SPREAD` / `SPREAD SKIP` HTML comment
+   blocks so the reusable workflow can generate a runnable `task.yaml` from it.
+2. `spread.yaml` — Spread project configuration at the repository root.
+3. `.github/workflows/spread_docs.yaml` — a thin workflow that delegates to
+   the reusable `docs_spread.yaml` workflow.
+
+Do **not** modify any other file. If you find yourself wanting to change
+anything else to make the test pass, stop and note it as a follow-up item
+instead.
+
+## Procedure
+
+### Step 1 — Gather context
+
+Read these references before you start. The first is the authoritative
+specification for SPREAD comment syntax; the other three are a working
+example from `canonical/synapse-operator`.
+
+- [SPREAD comment syntax spec](https://github.com/canonical/operator-workflows/blob/main/docs/how-to/docs_spread_manage_commands.md)
+- [synapse tutorial (example)](https://github.com/canonical/synapse-operator/blob/track/1/docs/tutorial/getting-started.md)
+- [synapse spread.yaml (example)](https://github.com/canonical/synapse-operator/blob/track/1/spread.yaml)
+- [synapse spread_docs.yaml (example)](https://github.com/canonical/synapse-operator/blob/track/1/.github/workflows/spread_docs.yaml)
+
+Also read the repository's own `docs/tutorial.md` end-to-end, plus
+`charmcraft.yaml` and `metadata.yaml` (whichever exists) to discover the
+charm's name.
+
+### Step 2 — Classify tutorial commands
+
+Walk every fenced code block in `docs/tutorial.md` in reading order. For each
+command inside a block, decide one of three outcomes using the criteria below.
+Do **not** rely on a hard-coded list of commands.
+
+Refer to [the command classification reference](./references/command-classification.md)
+for detailed criteria and examples.
+
+### Step 3 — Annotate `docs/tutorial.md`
+
+Apply the following mechanical rules:
+
+- The only permitted edits are additions of HTML comment blocks
+  (`<!-- SPREAD ... -->` and `<!-- SPREAD SKIP -->` … `<!-- SPREAD SKIP END -->`).
+  Never remove, reword, or reformat rendered content.
+- Every `<!-- SPREAD SKIP -->` must be closed by a matching
+  `<!-- SPREAD SKIP END -->` before the next top-level heading.
+- Every `<!-- SPREAD` hidden-command block must end with `-->` on its own
+  line, and the commands inside must not themselves contain `-->`.
+- Preserve existing frontmatter, MyST directives, cross-references, and image
+  references.
+- Do not touch code blocks that are language examples unrelated to the
+  tutorial commands (for instance, a `python` block that only shows a
+  snippet).
+
+### Step 4 — Generate `spread.yaml`
+
+Refer to [the spread.yaml reference](./references/spread-yaml-shape.md) for
+the required structure. Derive the charm name from `charmcraft.yaml` or
+`metadata.yaml` (`name:` field). If `spread.yaml` already exists, do **not**
+overwrite it — note the conflict as a follow-up.
+
+### Step 5 — Generate `.github/workflows/spread_docs.yaml`
+
+Refer to [the workflow reference](./references/spread-workflow-shape.md) for
+the required structure. If this file already exists, do **not** overwrite
+it — note the conflict as a follow-up.
+
+### Step 6 — Validate
+
+Run each check. If any fails, fix the generated files and re-run.
+
+1. `yamllint spread.yaml .github/workflows/spread_docs.yaml` — must exit
+   zero. (Skip the file if you chose not to write it because it already
+   existed.)
+2. Grep-based structural check on `docs/tutorial.md`:
+   - `grep -c '<!-- SPREAD SKIP -->' docs/tutorial.md` must equal
+     `grep -c '<!-- SPREAD SKIP END -->' docs/tutorial.md`.
+   - Every line matching `^<!-- SPREAD$` must have a matching `^-->$` line
+     later in the file (before the next `<!-- SPREAD` opener).
+3. `git status --porcelain` output must list only the three target paths
+   (`docs/tutorial.md`, `spread.yaml`,
+   `.github/workflows/spread_docs.yaml`). Any other entry is a bug — revert
+   it before proceeding.
+
+### Step 7 — Summarize
+
+Provide the user with:
+
+1. **Command mapping** — a Markdown table with columns
+   `Tutorial section` | `Command (trimmed)` |
+   `Classification (run / skip / skip+hidden)` | `Reason`.
+   Include one row per command classified. For *skip+hidden* rows,
+   quote the hidden replacement command in the *Reason* column.
+2. **Validation output** — trimmed `yamllint` output and the counts from
+   the grep-based structural check.
+3. **Follow-ups** — anything that could not be expressed as a SPREAD comment
+   (for example, a manual browser check with no automated equivalent), plus
+   any pre-existing `spread.yaml` or `.github/workflows/spread_docs.yaml`
+   that was not overwritten.

--- a/skills/prepare-docs-automated-spread-test/references/command-classification.md
+++ b/skills/prepare-docs-automated-spread-test/references/command-classification.md
@@ -1,0 +1,83 @@
+# Command Classification Reference
+
+Walk every fenced code block in `docs/tutorial.md` in reading order. For each
+command inside a block, decide one of three outcomes. Use these criteria — do
+**not** rely on a hard-coded list of commands.
+
+## 1. Keep visible and run (default)
+
+The command is deterministic, non-interactive, and a fresh CI runner can
+execute it without human input. Examples of the *shape* to look for:
+
+- Model/namespace creation.
+- Non-interactive `juju deploy`, `juju integrate`, `juju config`,
+  `juju refresh`.
+- Package or add-on installation that has an idempotent, non-prompting form.
+- Non-interactive file edits (append-to-`/etc/hosts` via `tee`, `sed -i`,
+  redirection).
+- HTTP smoke checks such as `curl -sSf ...`.
+
+Leave these blocks untouched.
+
+## 2. `SPREAD SKIP` with no hidden replacement
+
+The command or block is user-facing illustration that cannot or should not
+execute in CI, and no automated substitute is required. Examples of the
+*shape*:
+
+- Sample output blocks (`juju status`, `kubectl get ...`, log excerpts,
+  screenshots, terminal-style code fences that only show output).
+- "Open the browser and visit …" steps.
+- Manual DNS-provider edits.
+- Guidance to run something "inside a Multipass VM" — the reusable workflow
+  already provides its own runner.
+- Cleanup commands that would destroy the runner itself
+  (`multipass delete`, `snap remove` of tooling the runner still needs).
+- Interactive prompts (`sudo` with password entry, `read`, TUI editors).
+
+Wrap the block with:
+
+```markdown
+<!-- SPREAD SKIP -->
+
+...user-facing content that Spread must not run...
+
+<!-- SPREAD SKIP END -->
+```
+
+## 3. `SPREAD SKIP` with a hidden `<!-- SPREAD ... -->` replacement
+
+The visible command is illustrative for the reader but a deterministic
+equivalent is needed so Spread can run the tutorial unattended. Common
+patterns to look for:
+
+- Narrative "wait until the application is Active" or "run `juju status` until
+  you see …" — replace with an explicit
+  `juju wait-for application <app> --query='status=="active"' --timeout=30m`
+  hidden block, one per application the tutorial has deployed at that point.
+- A conditional-on-environment step (for example, "if RBAC is enabled, run
+  `juju trust …`") — replace with an unconditional deterministic equivalent
+  hidden block.
+- A visible interactive teardown (`juju destroy-model …` without `--no-prompt`,
+  `multipass delete` of a VM the tutorial created) — hide a non-interactive
+  equivalent (for example, add `--no-prompt --destroy-storage=true` or the
+  workload's equivalent). Keep the visible form inside SPREAD SKIP so
+  readers still see it.
+- A visible `juju bootstrap` guarded by "if not already bootstrapped" — if
+  the Spread `prepare` phase in `spread.yaml` already bootstraps a
+  controller, SPREAD SKIP the visible block and add no replacement.
+
+Insert the hidden block **immediately after** the visible SPREAD SKIP block
+it augments, so source order pairs them:
+
+```markdown
+<!-- SPREAD SKIP -->
+
+    juju destroy-model my-tutorial
+
+<!-- SPREAD SKIP END -->
+
+<!-- SPREAD
+juju destroy-model my-tutorial --no-prompt --destroy-storage=true
+-->
+```

--- a/skills/prepare-docs-automated-spread-test/references/spread-workflow-shape.md
+++ b/skills/prepare-docs-automated-spread-test/references/spread-workflow-shape.md
@@ -1,0 +1,28 @@
+# Target `.github/workflows/spread_docs.yaml` Shape
+
+If this file already exists, do **not** overwrite it. Record the conflict
+as a follow-up.
+
+## Required structure
+
+The generated file must:
+
+- Begin with the copyright header (use the current year):
+  ```
+  # Copyright <year> Canonical Ltd.
+  # See LICENSE file for licensing details.
+  ```
+- Use `name: Test documentation with Spread`.
+- Trigger on `workflow_dispatch`, a weekly `schedule` (`cron: '0 8 * * 1'`),
+  and `pull_request` filtered to `paths: ['docs/tutorial.md']`.
+- Define one job `tutorial-spread-test` that:
+  - `uses: canonical/operator-workflows/.github/workflows/docs_spread.yaml@main`
+  - `secrets: inherit`
+  - passes `with.input-file: docs/tutorial.md`,
+    `with.output-dir: tests/spread/tutorial/`,
+    `with.spread-job: github-ci:ubuntu-24.04-64:tests/spread/tutorial`.
+
+## Reference example
+
+See the synapse-operator workflow for a working example:
+<https://github.com/canonical/synapse-operator/blob/track/1/.github/workflows/spread_docs.yaml>

--- a/skills/prepare-docs-automated-spread-test/references/spread-yaml-shape.md
+++ b/skills/prepare-docs-automated-spread-test/references/spread-yaml-shape.md
@@ -1,0 +1,37 @@
+# Target `spread.yaml` Shape
+
+Derive the charm's name from `charmcraft.yaml` or `metadata.yaml` (the
+`name:` field). Fall back to the repository directory name only if neither
+file provides a name.
+
+If `spread.yaml` already exists at the repository root, do **not** overwrite
+it. Record the conflict as a follow-up and leave the file untouched.
+
+## Required structure
+
+The generated file must:
+
+- Begin with the copyright header (use the current year):
+  ```
+  # Copyright <year> Canonical Ltd.
+  # See LICENSE file for licensing details.
+  ```
+- Set `project: <charm-name>`, `path: /<charm-name>`, `kill-timeout: 90m`.
+- Set `environment` with `PROJECT_PATH: /<charm-name>`, empty `SUDO_USER`
+  and `SUDO_UID`, `LANG: "C.UTF-8"`, `LANGUAGE: "en"`.
+- Set `exclude` to `[.git, .github, .tox, .venv, .*_cache, charmcraft,
+  libexec, schema, snap]`.
+- Define `backends.github-ci` as a verbatim copy of the adhoc block from the
+  synapse reference (`type: adhoc`, `allocate` that requires
+  `GITHUB_RUN_ID`, `ADDRESS localhost:22`, a single
+  `ubuntu-24.04-64` system with `username: ubuntu`, `password: ubuntu`,
+  `workers: 1`).
+- Provide a project-level `prepare:` that installs concierge and runs
+  `sudo concierge prepare -p microk8s`, matching the synapse reference.
+- Declare `suites: tests/spread/:` with `summary: Charm tutorial test` and
+  `systems: [ubuntu-24.04-64]`.
+
+## Reference example
+
+See the synapse-operator spread.yaml for a working example:
+<https://github.com/canonical/synapse-operator/blob/track/1/spread.yaml>


### PR DESCRIPTION
This PR adds two new skills for scaffolding a deterministic test for a tutorial file using Spread.

`generate-docs-spread-test` — Generates standalone Spread test scaffolding from a charm's `docs/tutorial.md`. It extracts shell commands from the tutorial, classifies them into Spread lifecycle phases (prepare/execute/restore), and produces three files `spread.yaml`, `tests/spread/tutorial/task.yaml`, and a GitHub Actions workflow (`.github/workflows/spread_test.yaml`) that runs the Spread suite on dispatch, schedule, and PR changes.

`prepare-docs-automated-spread-test` — Prepares a charm repository to use the reusable `canonical/operator-workflows` docs Spread workflow. Instead of generating a full task file, it annotates `docs/tutorial.md` in-place with `<!-- SPREAD --> / <!-- SPREAD SKIP -->` HTML comments so the reusable workflow can derive the test at runtime. It also generates `spread.yaml` and a thin delegating workflow (`.github/workflows/spread_docs.yaml`).